### PR TITLE
make arpings thread safe, and ensure goroutines don't leak while waiting on socket receive

### DIFF
--- a/arping_test.go
+++ b/arping_test.go
@@ -1,13 +1,12 @@
 package arping
 
 import (
-	"testing"
 	"net"
-	"strings"
-	"time"
 	"runtime"
+	"strings"
+	"testing"
+	"time"
 )
-
 
 func TestPingWithInvalidIP(t *testing.T) {
 	ip := net.ParseIP("invalid")
@@ -66,7 +65,7 @@ func TestGoroutinesDoesNotLeak(t *testing.T) {
 	}
 
 	ok := make(chan bool, 1)
-	go func(){
+	go func() {
 		for {
 			if runtime.NumGoroutine() < spawnNumGoroutines {
 				ok <- true
@@ -86,7 +85,7 @@ func TestGoroutinesDoesNotLeak(t *testing.T) {
 }
 
 func validateInvalidV4AddrErr(t *testing.T, err error) {
-	if ! strings.Contains(err.Error(), "not a valid v4 Address") {
+	if !strings.Contains(err.Error(), "not a valid v4 Address") {
 		t.Errorf("unexpected error: %s", err)
 	}
 }


### PR DESCRIPTION
this PR fixes two issues:

 - arpings can't run in parallel as the `sock` fd is global. because of this, if there are overlap between arping runs, the socket fd will get replaced and the previous sockets won't be closed properly, causing the application to leak open sockets.
 - goroutines leaking when no response is received. as the RcvFrom method blocks until something is read from the socket, the goroutine where this was called won't exit. this can be seen by running `go test` in the main branch, the leak test never passes.

example:

```
/src/arping# docker run --mount type=bind,src=$(pwd),dst=/opt/src -w /opt/src -it golang:1.14 go test


--- FAIL: TestGoroutinesDoesNotLeak (30.06s)
    arping_test.go:83: timeout waiting for goroutine cleanup - num goroutines: 8
FAIL
exit status 1
FAIL	github.com/j-keck/arping	30.081s
```

and this is the result while testing on this branch
```
/src/arping# docker run --mount type=bind,src=$(pwd),dst=/opt/src -w /opt/src -it golang:1.14 go test
PASS
ok  	github.com/j-keck/arping	0.165s
```

i couldnt get the Bsd testing working (i am not very familiar with the OS family), but added similar changes anyway. test results using GOOS=freebsd / openbsd from my dev container look exactly the same. i'd be happy to make sure the code works if someone could provide me with guidance on that.

thank you for this cool package!

