### PR TITLE
check buffer length before accessing it

### DIFF
--- a/arping_bsd.go
+++ b/arping_bsd.go
@@ -96,6 +96,11 @@ func (s *BsdSocket) receive() (arpDatagram, time.Time, error) {
 	// skip bpf header + 14 bytes ethernet header
 	var hdrLength = bpfHdrLength + 14
 
+	if n <= hdrLength || len(buffer) <= hdrLength {
+		// amount of bytes read by socket is less than an ethernet header. clearly not what we look for
+		return arpDatagram{}, time.Now(), fmt.Errorf("buffer with invalid length")
+
+	}
 	return parseArpDatagram(buffer[hdrLength:n]), time.Now(), nil
 }
 

--- a/arping_linux.go
+++ b/arping_linux.go
@@ -1,6 +1,7 @@
 package arping
 
 import (
+	"fmt"
 	"net"
 	"syscall"
 	"time"
@@ -33,6 +34,11 @@ func (s *LinuxSocket) receive() (arpDatagram, time.Time, error) {
 	n, _, err := syscall.Recvfrom(s.sock, buffer, 0)
 	if err != nil {
 		return arpDatagram{}, time.Now(), err
+	}
+	if n <= 14 {
+		// amount of bytes read by socket is less than an ethernet header. clearly not what we look for
+		return arpDatagram{}, time.Now(), fmt.Errorf("buffer with invalid length")
+
 	}
 	// skip 14 bytes ethernet header
 	return parseArpDatagram(buffer[14:n]), time.Now(), nil


### PR DESCRIPTION
this PR checks if the amount of `bytes read` from socket is greater than the header we skip.
if buffer receives `len(something)<14`,  we'd end up with something like `buffer[14:0]`